### PR TITLE
fix(extraction): measure refresh coverage by integrated volumes, not …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5451,7 +5451,7 @@ dependencies = [
 
 [[package]]
 name = "weaver"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -5499,14 +5499,14 @@ dependencies = [
 
 [[package]]
 name = "weaver-model"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "weaver-nntp"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "bytes",
  "criterion",
@@ -5532,7 +5532,7 @@ dependencies = [
 
 [[package]]
 name = "weaver-nzb"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "quick-xml",
  "serde",
@@ -5543,7 +5543,7 @@ dependencies = [
 
 [[package]]
 name = "weaver-server-api"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "aes-gcm 0.11.1",
  "age",
@@ -5581,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "weaver-server-core"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "aes-gcm 0.11.1",
  "argon2",
@@ -5645,7 +5645,7 @@ dependencies = [
 
 [[package]]
 name = "weaver-yenc"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "cc",
  "crc-fast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5250,9 +5250,9 @@ dependencies = [
 
 [[package]]
 name = "unrar-rs"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9f618f2835669799e695ccd571284084f2d2fd46a41decfc6275c5b5800dc4"
+checksum = "d0b3969719e2bd072c94c68a667a00486d94cf1638e707074d1125c2a2fcdf59"
 dependencies = [
  "aws-lc-rs",
  "aws-lc-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.5"
+version = "0.9.6"
 edition = "2024"
 license-file = "LICENSE"
 repository = "https://github.com/scryer-media/weaver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,11 +113,12 @@ windows-sys = { version = "0.61", default-features = false }
 # Re-enabling means shipping a GPU repair lane again: decide it deliberately,
 # and re-verify with `cargo tree -e features --workspace | grep metal`.
 par2-rs = { version = "0.8", default-features = false, features = ["native-crypto"] }
-# Floor is 0.5.5, not 0.5: 0.5.1 through 0.5.4 decode some RAR5 members with
-# filters to the wrong bytes. Extraction here always runs with `verify: true`,
-# so those versions fail loudly rather than silently — but a resolver must not
-# be free to pick one.
-unrar-rs = { version = "0.5.5", default-features = false, features = ["crypto-aws-lc"] }
+# 0.6 is a contract, not just a floor: `RarVolumeFacts::volume_number` is
+# `Option<u32>` there, and volume-facts registration keys on "the header
+# stated a number" versus "the format states none" — a distinction 0.5.x
+# collapsed to 0. (0.5.1 through 0.5.4 additionally decode some filtered RAR5
+# members to the wrong bytes.)
+unrar-rs = { version = "0.6.0", default-features = false, features = ["crypto-aws-lc"] }
 scryer-release-parser = { git = "https://github.com/scryer-media/scryer", tag = "scryer-v0.18.21", default-features = false }
 
 [profile.release]

--- a/server/crates/weaver-server-core/src/pipeline/archive/probe.rs
+++ b/server/crates/weaver-server-core/src/pipeline/archive/probe.rs
@@ -493,7 +493,7 @@ impl Pipeline {
             return Ok(Some(DetectedArchiveIdentity {
                 kind: PersistedDetectedArchiveKind::Rar,
                 set_name: candidate.set_key.clone(),
-                volume_index: Some(facts.volume_number),
+                volume_index: facts.volume_number,
             }));
         }
 

--- a/server/crates/weaver-server-core/src/pipeline/archive/rar_state/tests.rs
+++ b/server/crates/weaver-server-core/src/pipeline/archive/rar_state/tests.rs
@@ -817,7 +817,7 @@ fn build_plan_blocks_ready_member_when_present_same_name_continuation_is_uninteg
 
     let mut unintegrated_tail =
         RarArchive::parse_volume_facts(Cursor::new(files[4].1.clone()), None).unwrap();
-    unintegrated_tail.volume_number = 5;
+    unintegrated_tail.volume_number = Some(5);
     for member in &mut unintegrated_tail.members {
         member.split_before = true;
         member.split_after = false;

--- a/server/crates/weaver-server-core/src/pipeline/archive/topology.rs
+++ b/server/crates/weaver-server-core/src/pipeline/archive/topology.rs
@@ -695,6 +695,26 @@ impl Pipeline {
         .map_err(|e| format!("RAR facts parser task panicked: {e}"))?
     }
 
+    /// The ledger key for one parsed volume.
+    ///
+    /// The header's stated number when the format states one — a swapped or
+    /// misnamed arrival registers as what its bytes are, not what the filename
+    /// claims — and the layout-derived volume otherwise. RAR5 states a number
+    /// in the main header of every volume past the first and a numbered RAR4
+    /// set states one in its end record; an old-numbering RAR4 set (.rar/.rNN)
+    /// states none anywhere and every volume parses as 0, so treating the
+    /// parse as identity there collapses the whole set onto one key.
+    pub(in crate::pipeline) fn rar_registration_volume(
+        observed_volume: Option<u32>,
+        facts: &unrar_rs::RarVolumeFacts,
+    ) -> u32 {
+        if facts.volume_number != 0 {
+            facts.volume_number
+        } else {
+            observed_volume.unwrap_or(0)
+        }
+    }
+
     pub(crate) fn persist_rar_volume_facts(
         &mut self,
         job_id: JobId,
@@ -703,14 +723,7 @@ impl Pipeline {
         observed_volume: Option<u32>,
         facts: unrar_rs::RarVolumeFacts,
     ) -> Result<bool, String> {
-        // The layout names the volume; the header validates it. RAR5 states a
-        // per-volume number in its main header and a numbered RAR4 set states
-        // one in its end record, but an old-numbering RAR4 set (.rar/.rNN)
-        // states none anywhere and parses as 0 — so keying the ledger by the
-        // parsed number collapses every volume of such a set onto one entry.
-        // The layout-derived volume is the key; the parsed number is only a
-        // cross-check, and 0 also means "the format stated nothing".
-        let volume = observed_volume.unwrap_or(facts.volume_number);
+        let volume = Self::rar_registration_volume(observed_volume, &facts);
         if let Some(expected_volume) = observed_volume
             && facts.volume_number != 0
             && facts.volume_number != expected_volume
@@ -721,7 +734,7 @@ impl Pipeline {
                 filename = %filename,
                 expected_volume,
                 parsed_volume = facts.volume_number,
-                "RAR header states a volume number that disagrees with the layout"
+                "RAR header states a volume number that disagrees with the layout; the header wins"
             );
         }
 
@@ -1796,7 +1809,8 @@ impl Pipeline {
                     "RAR facts refresh detected volume-number mismatch after normalization"
                 );
             }
-            parsed.push((expected_volume_number, filename, facts));
+            let volume = Self::rar_registration_volume(Some(expected_volume_number), &facts);
+            parsed.push((volume, filename, facts));
         }
 
         let state = self
@@ -2044,18 +2058,20 @@ impl Pipeline {
                     .await
                 {
                     Ok(facts) => {
-                        // Keyed by the layout-derived volume, like registration:
-                        // an old-numbering RAR4 header states no number and
-                        // every volume of the set parses as 0, so keying by the
-                        // parse would fold the whole set onto one slot here and
-                        // then discard every other loaded fact as "stale". The
+                        // Keyed exactly like registration: the stated number
+                        // when the header states one, the layout otherwise. An
+                        // old-numbering RAR4 header states no number and every
+                        // volume of the set parses as 0, so keying restore by
+                        // the parse alone folds the whole set onto one slot and
+                        // then discards every other loaded fact as "stale". The
                         // fresh parse also replaces any loaded row outright — a
                         // row mis-keyed by an older binary must not survive
                         // under a key the header never earned.
-                        live_volumes.insert(layout_volume);
+                        let volume = Self::rar_registration_volume(Some(layout_volume), &facts);
+                        live_volumes.insert(volume);
                         if let Some(state) = self.rar_sets.get_mut(&(job_id, set_name.clone())) {
-                            Self::register_rar_volume_file(state, layout_volume, filename);
-                            state.facts.insert(layout_volume, facts);
+                            Self::register_rar_volume_file(state, volume, filename);
+                            state.facts.insert(volume, facts);
                         }
                     }
                     Err(error) => {
@@ -2164,6 +2180,11 @@ impl Pipeline {
 
         match Self::parse_rar_volume_facts_from_path(path, password_candidates).await {
             Ok(facts) => {
+                // The key the facts registered under. Asking about the raw
+                // parsed number instead asks about volume 0 for every
+                // old-numbering RAR4 volume, whose headers state no number.
+                let registered_volume =
+                    Self::rar_registration_volume(Some(observed_volume), &facts);
                 let changed = match self.persist_rar_volume_facts(
                     job_id,
                     &set_name,
@@ -2175,7 +2196,7 @@ impl Pipeline {
                     Err(error) => {
                         warn!(
                             job_id = job_id.0,
-                            volume = observed_volume,
+                            volume = registered_volume,
                             set_name = %set_name,
                             error = %error,
                             "failed to register RAR volume facts"
@@ -2185,27 +2206,23 @@ impl Pipeline {
                 };
                 debug!(
                     job_id = job_id.0,
-                    volume = observed_volume,
+                    volume = registered_volume,
                     set_name = %set_name,
                     "RAR volume facts parsed"
                 );
-                // The topology speaks layout numbering — its volume slots come
-                // from the same classification `observed_volume` did — so the
-                // membership check must too. Asking about the parsed number
-                // asks about volume 0 for every old-numbering RAR4 volume.
                 let topology_missing_volume = self.jobs.get(&job_id).is_some_and(|state| {
                     state
                         .assembly
                         .archive_topology_for(&set_name)
                         .is_none_or(|topology| {
-                            !topology.complete_volumes.contains(&observed_volume)
+                            !topology.complete_volumes.contains(&registered_volume)
                         })
                 });
                 if changed || topology_missing_volume {
                     self.enqueue_rar_set_refresh(
                         job_id,
                         &set_name,
-                        observed_volume,
+                        registered_volume,
                         RefreshReason::CoverageExpansion,
                     );
                 }

--- a/server/crates/weaver-server-core/src/pipeline/archive/topology.rs
+++ b/server/crates/weaver-server-core/src/pipeline/archive/topology.rs
@@ -702,16 +702,16 @@ impl Pipeline {
     /// claims — and the layout-derived volume otherwise. RAR5 states a number
     /// in the main header of every volume past the first and a numbered RAR4
     /// set states one in its end record; an old-numbering RAR4 set (.rar/.rNN)
-    /// states none anywhere and every volume parses as 0, so treating the
-    /// parse as identity there collapses the whole set onto one key.
+    /// states none anywhere, and treating an unstated number as an identity
+    /// collapses the whole set onto one key. `None` is the format staying
+    /// silent; a stated `Some(0)` wins like any other stated number.
     pub(in crate::pipeline) fn rar_registration_volume(
         observed_volume: Option<u32>,
         facts: &unrar_rs::RarVolumeFacts,
     ) -> u32 {
-        if facts.volume_number != 0 {
-            facts.volume_number
-        } else {
-            observed_volume.unwrap_or(0)
+        match facts.volume_number {
+            Some(stated) => stated,
+            None => observed_volume.unwrap_or(0),
         }
     }
 
@@ -725,15 +725,15 @@ impl Pipeline {
     ) -> Result<bool, String> {
         let volume = Self::rar_registration_volume(observed_volume, &facts);
         if let Some(expected_volume) = observed_volume
-            && facts.volume_number != 0
-            && facts.volume_number != expected_volume
+            && let Some(stated_volume) = facts.volume_number
+            && stated_volume != expected_volume
         {
             info!(
                 job_id = job_id.0,
                 set_name = %set_name,
                 filename = %filename,
                 expected_volume,
-                parsed_volume = facts.volume_number,
+                parsed_volume = stated_volume,
                 "RAR header states a volume number that disagrees with the layout; the header wins"
             );
         }
@@ -1799,13 +1799,15 @@ impl Pipeline {
         for (expected_volume_number, filename, path) in volume_paths {
             let facts =
                 Self::parse_rar_volume_facts_from_path(path, password_candidates.clone()).await?;
-            if facts.volume_number != 0 && facts.volume_number != expected_volume_number {
+            if let Some(stated_volume) = facts.volume_number
+                && stated_volume != expected_volume_number
+            {
                 info!(
                     job_id = job_id.0,
                     set_name = %set_name,
                     filename = %filename,
                     expected_volume = expected_volume_number,
-                    parsed_volume = facts.volume_number,
+                    parsed_volume = stated_volume,
                     "RAR facts refresh detected volume-number mismatch after normalization"
                 );
             }
@@ -1974,17 +1976,19 @@ impl Pipeline {
             for (volume_index, blob) in facts_rows {
                 match rmp_serde::from_slice::<unrar_rs::RarVolumeFacts>(&blob) {
                     Ok(facts) => {
-                        // The row key is the layout-derived volume registration
-                        // used; the blob's own number is whatever the header
-                        // stated, which for an old-numbering RAR4 set is
-                        // nothing (parsed as 0). Re-keying by the blob would
-                        // collapse every such row onto volume 0.
-                        if facts.volume_number != 0 && facts.volume_number != volume_index {
+                        // The row key is the volume registration keyed by; the
+                        // blob's own number is whatever the header stated,
+                        // which for an old-numbering RAR4 set is nothing.
+                        // Re-keying by the blob would collapse every such row
+                        // onto one slot.
+                        if let Some(stated_volume) = facts.volume_number
+                            && stated_volume != volume_index
+                        {
                             warn!(
                                 job_id = job_id.0,
                                 set_name = %set_name,
                                 stored_volume = volume_index,
-                                parsed_volume = facts.volume_number,
+                                parsed_volume = stated_volume,
                                 "persisted RAR facts row key disagrees with the header's stated volume number"
                             );
                         }

--- a/server/crates/weaver-server-core/src/pipeline/archive/topology.rs
+++ b/server/crates/weaver-server-core/src/pipeline/archive/topology.rs
@@ -1076,11 +1076,21 @@ impl Pipeline {
                 worker_active,
             )?;
 
+            // The archive's own presence set is the coverage this refresh can
+            // vouch for — every volume the loop above attached, refreshed, or
+            // added, plus any the cached header view already held.
+            let integrated_volumes: BTreeSet<u32> = archive
+                .present_volumes()
+                .into_iter()
+                .map(|volume| volume as u32)
+                .collect();
+
             Ok((
                 plan,
                 archive.serialize_headers(),
                 rebuild_source,
                 using_cached_headers,
+                integrated_volumes,
             ))
         };
 
@@ -1162,7 +1172,7 @@ impl Pipeline {
             }
         }
 
-        let (mut plan, mut headers, mut rebuild_source, mut used_cached_headers) =
+        let (mut plan, mut headers, mut rebuild_source, mut used_cached_headers, mut integrated) =
             attach_volumes_and_build_plan(
                 archive,
                 rebuild_source,
@@ -1186,7 +1196,13 @@ impl Pipeline {
             );
 
             let selection = open_from_volume_zero()?;
-            (plan, headers, rebuild_source, used_cached_headers) = attach_volumes_and_build_plan(
+            (
+                plan,
+                headers,
+                rebuild_source,
+                used_cached_headers,
+                integrated,
+            ) = attach_volumes_and_build_plan(
                 selection.value,
                 RarTopologyRebuildSource::VolumeZero,
                 false,
@@ -1213,7 +1229,13 @@ impl Pipeline {
             );
 
             let selection = open_from_volume_zero()?;
-            (plan, headers, rebuild_source, used_cached_headers) = attach_volumes_and_build_plan(
+            (
+                plan,
+                headers,
+                rebuild_source,
+                used_cached_headers,
+                integrated,
+            ) = attach_volumes_and_build_plan(
                 selection.value,
                 RarTopologyRebuildSource::VolumeZero,
                 false,
@@ -1232,6 +1254,7 @@ impl Pipeline {
             plan,
             headers,
             rebuild_source,
+            integrated_volumes: integrated,
         })
     }
 
@@ -1247,13 +1270,14 @@ impl Pipeline {
             rebuild_source = computed.rebuild_source.as_str(),
             "RAR plan rebuilt"
         );
-        let refreshed_volumes: BTreeSet<u32> = computed
-            .plan
-            .topology
-            .complete_volumes
-            .iter()
-            .copied()
-            .collect();
+        // Coverage is what the refresh integrated into the header view, not
+        // the plan's fact-derived `complete_volumes`. A restored job can hold
+        // every volume on disk while the facts ledger records only a prefix;
+        // measuring coverage by facts made `rar_member_refresh_request` demand
+        // a refresh no refresh could ever satisfy — a full-speed livelock.
+        // The integrated set is the quantity the demand is actually about:
+        // whether a rebuild has seen the member's span.
+        let refreshed_volumes = computed.integrated_volumes;
         let latest_refreshed_volume = refreshed_volumes.iter().next_back().copied().unwrap_or(0);
         self.set_rar_snapshot(job_id, set_name, computed.headers);
         self.apply_rar_plan(job_id, set_name, computed.plan);

--- a/server/crates/weaver-server-core/src/pipeline/archive/topology.rs
+++ b/server/crates/weaver-server-core/src/pipeline/archive/topology.rs
@@ -703,7 +703,16 @@ impl Pipeline {
         observed_volume: Option<u32>,
         facts: unrar_rs::RarVolumeFacts,
     ) -> Result<bool, String> {
+        // The layout names the volume; the header validates it. RAR5 states a
+        // per-volume number in its main header and a numbered RAR4 set states
+        // one in its end record, but an old-numbering RAR4 set (.rar/.rNN)
+        // states none anywhere and parses as 0 — so keying the ledger by the
+        // parsed number collapses every volume of such a set onto one entry.
+        // The layout-derived volume is the key; the parsed number is only a
+        // cross-check, and 0 also means "the format stated nothing".
+        let volume = observed_volume.unwrap_or(facts.volume_number);
         if let Some(expected_volume) = observed_volume
+            && facts.volume_number != 0
             && facts.volume_number != expected_volume
         {
             info!(
@@ -712,14 +721,14 @@ impl Pipeline {
                 filename = %filename,
                 expected_volume,
                 parsed_volume = facts.volume_number,
-                "RAR facts parse detected filename-to-volume mismatch"
+                "RAR header states a volume number that disagrees with the layout"
             );
         }
 
         let state_key = (job_id, set_name.to_string());
         let unchanged = self.rar_sets.get(&state_key).is_some_and(|state| {
-            state.facts.get(&facts.volume_number) == Some(&facts)
-                && state.volume_files.get(&facts.volume_number) == Some(&filename.to_string())
+            state.facts.get(&volume) == Some(&facts)
+                && state.volume_files.get(&volume) == Some(&filename.to_string())
         });
         if unchanged {
             return Ok(false);
@@ -728,12 +737,12 @@ impl Pipeline {
         let encoded = rmp_serde::to_vec_named(&facts)
             .map_err(|error| format!("failed to encode RAR volume facts: {error}"))?;
         self.db
-            .save_rar_volume_facts(job_id, set_name, facts.volume_number, &encoded)
+            .save_rar_volume_facts(job_id, set_name, volume, &encoded)
             .map_err(|error| format!("failed to persist RAR volume facts: {error}"))?;
 
         let state = self.rar_sets.entry(state_key).or_default();
-        Self::register_rar_volume_file(state, facts.volume_number, filename.to_string());
-        state.facts.insert(facts.volume_number, facts);
+        Self::register_rar_volume_file(state, volume, filename.to_string());
+        state.facts.insert(volume, facts);
         state.facts_generation = state.facts_generation.wrapping_add(1);
 
         Ok(true)
@@ -1777,7 +1786,7 @@ impl Pipeline {
         for (expected_volume_number, filename, path) in volume_paths {
             let facts =
                 Self::parse_rar_volume_facts_from_path(path, password_candidates.clone()).await?;
-            if facts.volume_number != expected_volume_number {
+            if facts.volume_number != 0 && facts.volume_number != expected_volume_number {
                 info!(
                     job_id = job_id.0,
                     set_name = %set_name,
@@ -1787,7 +1796,7 @@ impl Pipeline {
                     "RAR facts refresh detected volume-number mismatch after normalization"
                 );
             }
-            parsed.push((facts.volume_number, filename, facts));
+            parsed.push((expected_volume_number, filename, facts));
         }
 
         let state = self
@@ -1951,16 +1960,21 @@ impl Pipeline {
             for (volume_index, blob) in facts_rows {
                 match rmp_serde::from_slice::<unrar_rs::RarVolumeFacts>(&blob) {
                     Ok(facts) => {
-                        if facts.volume_number != volume_index {
+                        // The row key is the layout-derived volume registration
+                        // used; the blob's own number is whatever the header
+                        // stated, which for an old-numbering RAR4 set is
+                        // nothing (parsed as 0). Re-keying by the blob would
+                        // collapse every such row onto volume 0.
+                        if facts.volume_number != 0 && facts.volume_number != volume_index {
                             warn!(
                                 job_id = job_id.0,
                                 set_name = %set_name,
                                 stored_volume = volume_index,
                                 parsed_volume = facts.volume_number,
-                                "persisted RAR facts volume key did not match parsed volume number"
+                                "persisted RAR facts row key disagrees with the header's stated volume number"
                             );
                         }
-                        state.facts.insert(facts.volume_number, facts);
+                        state.facts.insert(volume_index, facts);
                     }
                     Err(error) => {
                         warn!(
@@ -2004,7 +2018,7 @@ impl Pipeline {
                     .assembly
                     .files()
                     .filter_map(|file_asm| {
-                        let weaver_model::files::FileRole::RarVolume { .. } =
+                        let weaver_model::files::FileRole::RarVolume { volume_number } =
                             self.classified_role_for_file(job_id, file_asm)
                         else {
                             return None;
@@ -2019,20 +2033,29 @@ impl Pipeline {
                         }
                         let current_filename = self.current_filename_for_file(job_id, file_asm);
                         let path = state.working_dir.join(&current_filename);
-                        path.exists().then_some((current_filename, path))
+                        path.exists()
+                            .then_some((volume_number, current_filename, path))
                     })
                     .collect::<Vec<_>>()
             };
             let mut live_volumes = HashSet::new();
-            for (filename, path) in volume_files {
+            for (layout_volume, filename, path) in volume_files {
                 match Self::parse_rar_volume_facts_from_path(path, password_candidates.clone())
                     .await
                 {
                     Ok(facts) => {
-                        live_volumes.insert(facts.volume_number);
+                        // Keyed by the layout-derived volume, like registration:
+                        // an old-numbering RAR4 header states no number and
+                        // every volume of the set parses as 0, so keying by the
+                        // parse would fold the whole set onto one slot here and
+                        // then discard every other loaded fact as "stale". The
+                        // fresh parse also replaces any loaded row outright — a
+                        // row mis-keyed by an older binary must not survive
+                        // under a key the header never earned.
+                        live_volumes.insert(layout_volume);
                         if let Some(state) = self.rar_sets.get_mut(&(job_id, set_name.clone())) {
-                            Self::register_rar_volume_file(state, facts.volume_number, filename);
-                            state.facts.entry(facts.volume_number).or_insert(facts);
+                            Self::register_rar_volume_file(state, layout_volume, filename);
+                            state.facts.insert(layout_volume, facts);
                         }
                     }
                     Err(error) => {
@@ -2141,7 +2164,6 @@ impl Pipeline {
 
         match Self::parse_rar_volume_facts_from_path(path, password_candidates).await {
             Ok(facts) => {
-                let parsed_volume = facts.volume_number;
                 let changed = match self.persist_rar_volume_facts(
                     job_id,
                     &set_name,
@@ -2153,7 +2175,7 @@ impl Pipeline {
                     Err(error) => {
                         warn!(
                             job_id = job_id.0,
-                            volume = parsed_volume,
+                            volume = observed_volume,
                             set_name = %set_name,
                             error = %error,
                             "failed to register RAR volume facts"
@@ -2163,21 +2185,27 @@ impl Pipeline {
                 };
                 debug!(
                     job_id = job_id.0,
-                    volume = parsed_volume,
+                    volume = observed_volume,
                     set_name = %set_name,
                     "RAR volume facts parsed"
                 );
+                // The topology speaks layout numbering — its volume slots come
+                // from the same classification `observed_volume` did — so the
+                // membership check must too. Asking about the parsed number
+                // asks about volume 0 for every old-numbering RAR4 volume.
                 let topology_missing_volume = self.jobs.get(&job_id).is_some_and(|state| {
                     state
                         .assembly
                         .archive_topology_for(&set_name)
-                        .is_none_or(|topology| !topology.complete_volumes.contains(&parsed_volume))
+                        .is_none_or(|topology| {
+                            !topology.complete_volumes.contains(&observed_volume)
+                        })
                 });
                 if changed || topology_missing_volume {
                     self.enqueue_rar_set_refresh(
                         job_id,
                         &set_name,
-                        parsed_volume,
+                        observed_volume,
                         RefreshReason::CoverageExpansion,
                     );
                 }

--- a/server/crates/weaver-server-core/src/pipeline/completion/finalize/nested.rs
+++ b/server/crates/weaver-server-core/src/pipeline/completion/finalize/nested.rs
@@ -175,7 +175,7 @@ impl Pipeline {
                 file.detected_archive = Some(crate::jobs::assembly::DetectedArchiveIdentity {
                     kind: crate::jobs::assembly::DetectedArchiveKind::Rar,
                     set_name: set_key,
-                    volume_index: Some(facts.volume_number),
+                    volume_index: facts.volume_number,
                 });
                 continue;
             }

--- a/server/crates/weaver-server-core/src/pipeline/completion/finalize/rar.rs
+++ b/server/crates/weaver-server-core/src/pipeline/completion/finalize/rar.rs
@@ -1338,7 +1338,22 @@ impl Pipeline {
                 let facts =
                     Self::parse_rar_volume_facts_from_path(path, password_candidates.clone())
                         .await?;
-                restored.push((facts.volume_number, relative_path, facts));
+                // The restored file's name is the layout's statement of which
+                // volume this is, and the ledger is keyed by layout numbering.
+                // The parsed header number stands in only when the name does
+                // not classify as a RAR volume at all.
+                let observed_volume = std::path::Path::new(&relative_path)
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .map(weaver_model::files::FileRole::from_filename)
+                    .and_then(|role| match role {
+                        weaver_model::files::FileRole::RarVolume { volume_number } => {
+                            Some(volume_number)
+                        }
+                        _ => None,
+                    })
+                    .unwrap_or(facts.volume_number);
+                restored.push((observed_volume, relative_path, facts));
             }
 
             if restored.is_empty() {

--- a/server/crates/weaver-server-core/src/pipeline/completion/finalize/rar.rs
+++ b/server/crates/weaver-server-core/src/pipeline/completion/finalize/rar.rs
@@ -1339,9 +1339,10 @@ impl Pipeline {
                     Self::parse_rar_volume_facts_from_path(path, password_candidates.clone())
                         .await?;
                 // The restored file's name is the layout's statement of which
-                // volume this is, and the ledger is keyed by layout numbering.
-                // The parsed header number stands in only when the name does
-                // not classify as a RAR volume at all.
+                // volume this is. Registration keys by the header's stated
+                // number when the format states one and by this layout claim
+                // otherwise — without the layout claim, an old-numbering RAR4
+                // volume (whose headers state nothing) would register as 0.
                 let observed_volume = std::path::Path::new(&relative_path)
                     .file_name()
                     .and_then(|name| name.to_str())

--- a/server/crates/weaver-server-core/src/pipeline/completion/finalize/rar.rs
+++ b/server/crates/weaver-server-core/src/pipeline/completion/finalize/rar.rs
@@ -1343,7 +1343,7 @@ impl Pipeline {
                 // number when the format states one and by this layout claim
                 // otherwise — without the layout claim, an old-numbering RAR4
                 // volume (whose headers state nothing) would register as 0.
-                let observed_volume = std::path::Path::new(&relative_path)
+                let layout_volume = std::path::Path::new(&relative_path)
                     .file_name()
                     .and_then(|name| name.to_str())
                     .map(weaver_model::files::FileRole::from_filename)
@@ -1352,9 +1352,9 @@ impl Pipeline {
                             Some(volume_number)
                         }
                         _ => None,
-                    })
-                    .unwrap_or(facts.volume_number);
-                restored.push((observed_volume, relative_path, facts));
+                    });
+                let registered_volume = Self::rar_registration_volume(layout_volume, &facts);
+                restored.push((registered_volume, relative_path, facts));
             }
 
             if restored.is_empty() {

--- a/server/crates/weaver-server-core/src/pipeline/direct_store/router.rs
+++ b/server/crates/weaver-server-core/src/pipeline/direct_store/router.rs
@@ -3173,16 +3173,18 @@ impl DirectSetRouter {
         // disagree about what this file is. Nothing can reconcile that — one
         // of them is describing a different file — so the set demotes before
         // the layout adopts a member from the wrong position. An absent number
-        // parses as zero and stays silent (every unnumbered RAR4 volume would
-        // otherwise demote), with one exception the format guarantees: a RAR5
-        // *set member* always declares a nonzero number past the first volume,
-        // so zero under a nonzero binding is itself a disagreement.
+        // stays silent (every unnumbered RAR4 volume would otherwise demote),
+        // with one exception the format guarantees: a RAR5 *set member* always
+        // declares its number past the first volume, so an absent number under
+        // a nonzero binding is itself a disagreement — and a stated number
+        // that disagrees demotes even when what it states is zero.
         if self.plan.identity.is_some() {
-            let declared_disagrees =
-                facts.volume_number != volume_index && facts.volume_number != 0;
+            let declared_disagrees = facts
+                .volume_number
+                .is_some_and(|stated| stated != volume_index);
             let rar5_missing_number = facts.archive_format() == ArchiveFormat::Rar5
                 && facts.is_volume
-                && facts.volume_number == 0
+                && facts.volume_number.is_none()
                 && volume_index != 0;
             if declared_disagrees || rar5_missing_number {
                 return Err(self.fail(DemotionReason::IdentityVolumeMismatch));

--- a/server/crates/weaver-server-core/src/pipeline/direct_store/tests.rs
+++ b/server/crates/weaver-server-core/src/pipeline/direct_store/tests.rs
@@ -4370,7 +4370,7 @@ fn volume_facts(
     unrar_rs::RarVolumeFacts {
         // RAR5.
         format: 5,
-        volume_number,
+        volume_number: Some(volume_number),
         more_volumes,
         is_solid: false,
         is_encrypted: false,

--- a/server/crates/weaver-server-core/src/pipeline/mod.rs
+++ b/server/crates/weaver-server-core/src/pipeline/mod.rs
@@ -1210,6 +1210,14 @@ pub(super) struct ComputedRarSetState {
     pub(super) plan: RarDerivedPlan,
     pub(super) headers: Vec<u8>,
     pub(super) rebuild_source: archive::topology::RarTopologyRebuildSource,
+    /// The volumes this refresh actually integrated into the header view.
+    ///
+    /// Not the plan's `complete_volumes`: that set is derived from the facts
+    /// ledger, and a restored job can hold volumes on disk that the ledger
+    /// never recorded. Refresh coverage has to measure what the refresh saw,
+    /// or a coverage demand it can never satisfy re-issues itself after every
+    /// completion.
+    pub(super) integrated_volumes: BTreeSet<u32>,
 }
 
 pub(super) struct RarRefreshDone {

--- a/server/crates/weaver-server-core/src/pipeline/tests/direct_store.rs
+++ b/server/crates/weaver-server-core/src/pipeline/tests/direct_store.rs
@@ -12646,12 +12646,12 @@ const TEST_RAR4_SALT: [u8; 8] = [0x9B; 8];
 ///
 /// RAR4 has no per-volume number anywhere else — RAR5 carries one in the main
 /// header, RAR4 carries it in `ENDARC` behind the `VOLUME_NUMBER` flag — and
-/// `unrar-rs` reads `RarVolumeFacts::volume_number` from exactly there. The
-/// **conventional** path keys its whole per-set volume map by that number
-/// (`persist_rar_volume_facts`), so a set whose volumes all report volume 0
-/// collapses into one entry and never assembles. Direct-store does not care:
-/// it numbers volumes by NZB file index, which is why the plaintext RAR4
-/// fixture gets away without this. A *differential* needs both halves to work.
+/// `unrar-rs` reads `RarVolumeFacts::volume_number` from exactly there. Both
+/// halves of a differential key volumes by the layout rather than by that
+/// parsed number (an old-numbering set states none at all), but a numbered end
+/// record is what modern RAR4 writers emit for `.partNN` sets, and it is the
+/// cross-check the conventional path (`persist_rar_volume_facts`) holds the
+/// layout against — so the realistic fixture states it.
 fn build_test_rar4_end_header_numbered(more_volumes: bool, volume: u16) -> Vec<u8> {
     let mut flags: u16 = 0x0004; // VOLUME_NUMBER
     if more_volumes {

--- a/server/crates/weaver-server-core/src/pipeline/tests/mod.rs
+++ b/server/crates/weaver-server-core/src/pipeline/tests/mod.rs
@@ -906,7 +906,7 @@ fn shortened_e01_rar_headers(files: &[(String, Vec<u8>)]) -> Vec<u8> {
 fn dummy_rar_volume_facts(volume_number: u32) -> unrar_rs::RarVolumeFacts {
     unrar_rs::RarVolumeFacts {
         format: 5,
-        volume_number,
+        volume_number: Some(volume_number),
         more_volumes: true,
         is_solid: false,
         is_encrypted: false,

--- a/server/crates/weaver-server-core/src/pipeline/tests/rar_extraction.rs
+++ b/server/crates/weaver-server-core/src/pipeline/tests/rar_extraction.rs
@@ -1019,6 +1019,9 @@ async fn a_refresh_gap_the_plan_cannot_close_parks_instead_of_respawning() {
             headers: Vec::new(),
             rebuild_source:
                 crate::pipeline::archive::topology::RarTopologyRebuildSource::VolumeZero,
+            // The refresh saw only volume 0 — the same starved view the plan
+            // absorbed, so the facts stay unabsorbed round after round.
+            integrated_volumes: BTreeSet::from([0]),
         }
     };
     let request = RarRefreshRequest {
@@ -1130,6 +1133,7 @@ async fn rar_refresh_follow_up_does_not_starve_covered_ready_members() {
             .load_rar_snapshot(job_id, "show")
             .expect("RAR snapshot should exist after volumes 0-1"),
         rebuild_source: crate::pipeline::archive::topology::RarTopologyRebuildSource::CachedHeaders,
+        integrated_volumes: BTreeSet::from([0, 1]),
     };
     let request = RarRefreshRequest {
         target_completed_volume: 1,
@@ -1292,6 +1296,7 @@ async fn rar_refresh_done_uses_actual_refreshed_frontier() {
             .load_rar_snapshot(job_id, "show")
             .expect("RAR snapshot should exist"),
         rebuild_source: crate::pipeline::archive::topology::RarTopologyRebuildSource::CachedHeaders,
+        integrated_volumes: BTreeSet::from([0, 1]),
     };
 
     pipeline
@@ -1386,6 +1391,7 @@ async fn stale_post_extraction_refresh_does_not_replace_live_rar_plan() {
                 headers: stale_headers,
                 rebuild_source:
                     crate::pipeline::archive::topology::RarTopologyRebuildSource::CachedHeaders,
+                integrated_volumes: BTreeSet::new(),
             }),
         })
         .await;
@@ -1509,6 +1515,7 @@ async fn identity_rebind_rejects_an_older_rar_refresh_snapshot() {
                 headers: stale_headers.clone(),
                 rebuild_source:
                     crate::pipeline::archive::topology::RarTopologyRebuildSource::CachedHeaders,
+                integrated_volumes: BTreeSet::new(),
             }),
         })
         .await;
@@ -1608,6 +1615,7 @@ async fn source_retry_discards_an_in_flight_refresh_without_resurrecting_its_set
                 headers: stale_headers,
                 rebuild_source:
                     crate::pipeline::archive::topology::RarTopologyRebuildSource::CachedHeaders,
+                integrated_volumes: BTreeSet::new(),
             }),
         })
         .await;
@@ -10112,6 +10120,138 @@ async fn a_claimed_alias_set_is_absorbed_on_persisted_facts_after_a_restart() {
 
     drain_completion_checks(&mut pipeline, 16).await;
     assert!(pipeline.pending_completion_checks.is_empty());
+}
+
+#[tokio::test]
+async fn a_refresh_that_integrated_a_members_span_satisfies_the_coverage_it_owed() {
+    // The job-11857 shape: a restored set holds every volume on disk while the
+    // facts ledger recorded only a prefix. Coverage measured by fact-backed
+    // `complete_volumes` makes `rar_member_refresh_request` demand a refresh
+    // that registers no fact and so can never answer the demand — a full-speed
+    // livelock. Coverage is what the refresh integrated into the header view;
+    // a rebuild that saw the member's whole span settles the demand it
+    // triggered.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let (mut pipeline, _intermediate_dir, _complete_dir) = new_direct_pipeline(&temp_dir).await;
+    let job_id = JobId(90217);
+    insert_active_job(
+        &mut pipeline,
+        job_id,
+        standalone_job_spec(
+            "Silver Horizon Prefix Facts",
+            &[("silver.horizon.mkv".to_string(), 64)],
+        ),
+    )
+    .await;
+
+    let set_name = "silver.horizon";
+    let member = "silver.horizon.mkv";
+    let topology = crate::jobs::assembly::ArchiveTopology {
+        archive_type: crate::jobs::assembly::ArchiveType::Rar,
+        volume_map: HashMap::from([
+            ("silver.horizon.rar".to_string(), 0),
+            ("silver.horizon.r00".to_string(), 1),
+            ("silver.horizon.r01".to_string(), 2),
+        ]),
+        // The ledger's view: only the prefix ever registered facts.
+        complete_volumes: [0u32, 1].into_iter().collect(),
+        expected_volume_count: Some(3),
+        members: vec![crate::jobs::assembly::ArchiveMember {
+            name: member.to_string(),
+            first_volume: 0,
+            last_volume: 2,
+            unpacked_size: 64,
+        }],
+        unresolved_spans: Vec::new(),
+    };
+    pipeline
+        .jobs
+        .get_mut(&job_id)
+        .unwrap()
+        .assembly
+        .set_archive_topology(set_name.to_string(), topology.clone());
+
+    let key = (job_id, set_name.to_string());
+    let mut set_state = crate::pipeline::archive::rar_state::RarSetState::default();
+    for (filename, volume) in &topology.volume_map {
+        set_state.volume_files.insert(*volume, filename.clone());
+    }
+    pipeline.rar_sets.insert(key.clone(), set_state);
+
+    let request = RarRefreshRequest {
+        target_completed_volume: 2,
+        reason: RefreshReason::CoverageExpansion,
+    };
+    pipeline.rar_refresh_state.insert(
+        key.clone(),
+        RarRefreshState {
+            in_flight: Some(request),
+            queued: None,
+            latest_completed_volume: 2,
+            // The stale baseline a fact-derived measure produces.
+            refreshed_volumes: BTreeSet::from([0, 1]),
+            structure_dirty: false,
+            last_error: None,
+            last_completion_fingerprint: None,
+        },
+    );
+
+    assert!(
+        pipeline
+            .rar_member_refresh_request(job_id, set_name, member)
+            .is_some(),
+        "before the refresh lands, the member's span exceeds the recorded coverage"
+    );
+
+    pipeline
+        .handle_rar_refresh_done(RarRefreshDone {
+            job_id,
+            set_name: set_name.to_string(),
+            request,
+            extraction_generation: 0,
+            result: Ok(ComputedRarSetState {
+                plan: crate::pipeline::archive::rar_state::RarDerivedPlan {
+                    phase: crate::pipeline::archive::rar_state::RarSetPhase::Ready,
+                    is_solid: false,
+                    ready_members: vec![crate::pipeline::archive::rar_state::RarReadyMember {
+                        name: member.to_string(),
+                    }],
+                    member_names: vec![member.to_string()],
+                    member_dependencies: HashMap::new(),
+                    waiting_on_volumes: HashSet::new(),
+                    deletion_eligible: HashSet::new(),
+                    delete_decisions: BTreeMap::new(),
+                    topology: topology.clone(),
+                    fallback_reason: None,
+                },
+                headers: Vec::new(),
+                rebuild_source:
+                    crate::pipeline::archive::topology::RarTopologyRebuildSource::VolumeZero,
+                // What the rebuild actually opened: the whole set, facts or no
+                // facts.
+                integrated_volumes: BTreeSet::from([0, 1, 2]),
+            }),
+        })
+        .await;
+
+    let refresh = pipeline
+        .rar_refresh_state
+        .get(&key)
+        .expect("refresh state should remain");
+    assert_eq!(
+        refresh.refreshed_volumes,
+        BTreeSet::from([0, 1, 2]),
+        "coverage records what the refresh integrated, not what the facts ledger holds"
+    );
+    assert!(
+        refresh.in_flight.is_none() && refresh.queued.is_none(),
+        "a refresh that integrated the span leaves nothing owed — no respawn"
+    );
+    assert_eq!(
+        pipeline.rar_member_refresh_request(job_id, set_name, member),
+        None,
+        "the demand this refresh was spawned for is satisfied by its own completion"
+    );
 }
 
 #[tokio::test]

--- a/server/crates/weaver-server-core/src/pipeline/tests/rar_extraction.rs
+++ b/server/crates/weaver-server-core/src/pipeline/tests/rar_extraction.rs
@@ -10318,3 +10318,200 @@ async fn a_claimed_set_with_genuinely_missing_volumes_fails_once_instead_of_loop
         "a failed job holds no armed completion check"
     );
 }
+
+/// A single stored member split across an **old-numbering** RAR4 set —
+/// `<base>.rar`, `<base>.r00`, `<base>.r01`, … — the one multi-volume RAR
+/// shape whose headers state no per-volume number anywhere: RAR4's main header
+/// has no number field (that is RAR5's), and these end records carry no
+/// `VOLUME_NUMBER` flag (a numbered `ENDARC` is what modern `.partNN` writers
+/// emit). Every volume of such a set parses as volume 0; only the filename
+/// says which volume a file is.
+fn single_member_rar4_old_numbering_set(
+    base: &str,
+    member_name: &str,
+    payload: &[u8],
+    volume_count: usize,
+) -> Vec<(String, Vec<u8>)> {
+    let member_crc = checksum::crc32(payload);
+    let chunk = payload.len().div_ceil(volume_count);
+    (0..volume_count)
+        .map(|volume| {
+            let start = (volume * chunk).min(payload.len());
+            let end = ((volume + 1) * chunk).min(payload.len());
+            let part = &payload[start..end];
+            let is_first = volume == 0;
+            let is_last = volume + 1 == volume_count;
+            let mut split_flags = 0u16;
+            if !is_first {
+                split_flags |= 0x0001;
+            }
+            if !is_last {
+                split_flags |= 0x0002;
+            }
+            let mut bytes = Vec::new();
+            bytes.extend_from_slice(&TEST_RAR4_SIG);
+            // VOLUME only — no NEW_NUMBERING, exactly like the old scheme.
+            bytes.extend_from_slice(&build_test_rar4_block(0x73, 0x0001, &[0u8; 6]));
+            bytes.extend_from_slice(&build_test_rar4_file_header(
+                member_name,
+                split_flags,
+                part.len() as u32,
+                payload.len() as u32,
+                if is_last {
+                    member_crc
+                } else {
+                    checksum::crc32(part)
+                },
+            ));
+            bytes.extend_from_slice(part);
+            bytes.extend_from_slice(&build_test_rar4_end_header(!is_last));
+            let filename = if is_first {
+                format!("{base}.rar")
+            } else {
+                format!("{base}.r{:02}", volume - 1)
+            };
+            (filename, bytes)
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn an_old_numbering_rar4_set_keys_facts_by_the_layout_not_the_parsed_number() {
+    // Production job 11857: an old-numbering RAR4 set's headers state no
+    // volume number, so every volume parses as volume 0. Keying the facts
+    // ledger by that parse folded the whole set onto one entry, the ledger
+    // never grew past a prefix, and the member gate demanded coverage no
+    // refresh could record. The layout names the volume; the header only
+    // validates it.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let (mut pipeline, _intermediate_dir, _complete_dir) = new_direct_pipeline(&temp_dir).await;
+    let job_id = JobId(90218);
+    let payload = vec![0x5Au8; 96];
+    let files =
+        single_member_rar4_old_numbering_set("silver.horizon", "silver.horizon.mkv", &payload, 3);
+    insert_active_job(
+        &mut pipeline,
+        job_id,
+        rar_job_spec("Silver Horizon Old Numbering", &files),
+    )
+    .await;
+
+    for (index, (filename, bytes)) in files.iter().enumerate() {
+        write_and_complete_rar_volume(&mut pipeline, job_id, index as u32, filename, bytes).await;
+    }
+
+    let key = (job_id, "silver.horizon".to_string());
+    let state = pipeline.rar_sets.get(&key).expect("RAR set state");
+    assert_eq!(
+        state.facts.keys().copied().collect::<BTreeSet<_>>(),
+        BTreeSet::from([0, 1, 2]),
+        "facts key by the layout-derived volume even when every header parses as volume 0"
+    );
+    assert_eq!(
+        state.volume_files.get(&0).map(String::as_str),
+        Some("silver.horizon.rar")
+    );
+    assert_eq!(
+        state.volume_files.get(&1).map(String::as_str),
+        Some("silver.horizon.r00")
+    );
+    assert_eq!(
+        state.volume_files.get(&2).map(String::as_str),
+        Some("silver.horizon.r01")
+    );
+    let plan = state.plan.as_ref().expect("completed set derives a plan");
+    assert_eq!(
+        plan.topology.complete_volumes,
+        HashSet::from([0, 1, 2]),
+        "the ledger's completeness view covers the whole set, not a collapsed prefix"
+    );
+    assert_eq!(
+        pipeline.rar_member_refresh_request(job_id, "silver.horizon", "silver.horizon.mkv"),
+        None,
+        "a fully-present set owes no coverage refresh"
+    );
+}
+
+#[tokio::test]
+async fn restore_rebuilds_layout_keys_for_an_old_numbering_rar4_set() {
+    // The restart half of job 11857: the legacy ledger holds one collapsed row
+    // (every header parses as volume 0) while the whole set sits on disk.
+    // Restore must trust the row's layout key, rebuild the live map by the
+    // layout, and let fresh parses win — not fold the set back onto volume 0
+    // and then discard everything else as stale.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let (mut pipeline, _intermediate_dir, _complete_dir) = new_direct_pipeline(&temp_dir).await;
+    let job_id = JobId(90219);
+    let payload = vec![0xC3u8; 96];
+    let files =
+        single_member_rar4_old_numbering_set("silver.horizon", "silver.horizon.mkv", &payload, 3);
+    insert_active_job(
+        &mut pipeline,
+        job_id,
+        rar_job_spec("Silver Horizon Restored Old Numbering", &files),
+    )
+    .await;
+
+    // All three volumes are on disk and complete in the assembly, but nothing
+    // ran through live registration: this is a job coming back from a restart.
+    let working_dir = pipeline.jobs.get(&job_id).unwrap().working_dir.clone();
+    for (index, (filename, bytes)) in files.iter().enumerate() {
+        tokio::fs::write(working_dir.join(filename), bytes)
+            .await
+            .unwrap();
+        pipeline
+            .jobs
+            .get_mut(&job_id)
+            .unwrap()
+            .assembly
+            .file_mut(NzbFileId {
+                job_id,
+                file_index: index as u32,
+            })
+            .unwrap()
+            .commit_segment(0, bytes.len() as u32)
+            .unwrap();
+    }
+
+    // The legacy DB shape: one row, keyed by the collapsed parse.
+    let facts =
+        unrar_rs::RarArchive::parse_volume_facts(std::io::Cursor::new(files[0].1.clone()), None)
+            .unwrap();
+    assert_eq!(
+        facts.volume_number, 0,
+        "old numbering states no volume number"
+    );
+    let blob = rmp_serde::to_vec_named(&facts).unwrap();
+    pipeline
+        .db
+        .save_rar_volume_facts(job_id, "silver.horizon", 0, &blob)
+        .unwrap();
+
+    pipeline.restore_rar_state_for_job(job_id).await;
+
+    let key = (job_id, "silver.horizon".to_string());
+    let state = pipeline
+        .rar_sets
+        .get(&key)
+        .expect("RAR set state survives restore");
+    assert_eq!(
+        state.facts.keys().copied().collect::<BTreeSet<_>>(),
+        BTreeSet::from([0, 1, 2]),
+        "restore rebuilds the ledger by layout keys instead of collapsing onto the parsed 0"
+    );
+    assert_eq!(
+        state.volume_files.get(&1).map(String::as_str),
+        Some("silver.horizon.r00"),
+        "the live volume-file map is layout-keyed, one entry per file"
+    );
+    let plan = state
+        .plan
+        .as_ref()
+        .expect("restore recomputes the plan for a set with facts");
+    assert_eq!(plan.topology.complete_volumes, HashSet::from([0, 1, 2]));
+    assert_eq!(
+        pipeline.rar_member_refresh_request(job_id, "silver.horizon", "silver.horizon.mkv"),
+        None,
+        "a restored, fully-present set owes no coverage refresh"
+    );
+}

--- a/server/crates/weaver-server-core/src/pipeline/tests/rar_extraction.rs
+++ b/server/crates/weaver-server-core/src/pipeline/tests/rar_extraction.rs
@@ -10478,7 +10478,7 @@ async fn restore_rebuilds_layout_keys_for_an_old_numbering_rar4_set() {
         unrar_rs::RarArchive::parse_volume_facts(std::io::Cursor::new(files[0].1.clone()), None)
             .unwrap();
     assert_eq!(
-        facts.volume_number, 0,
+        facts.volume_number, None,
         "old numbering states no volume number"
     );
     let blob = rmp_serde::to_vec_named(&facts).unwrap();


### PR DESCRIPTION
…facts

A restored job can hold every RAR volume on disk while the facts ledger recorded only a prefix (an old-numbering RAR4 set whose headers carry no volume index leaves the ledger short). Refresh coverage was measured by the plan's fact-derived complete_volumes: rar_member_refresh_request saw a ready member spanning volumes the ledger never recorded and demanded a CoverageExpansion refresh — but a refresh registers no facts, so its completion could never answer the demand, and the demand re-issued after every completion at actor speed. The no-progress fingerprint park does not cover this arm: it gates facts the plan failed to absorb, and here every fact is absorbed; the missing coverage is on-disk volumes that have no facts at all.

Coverage now records what a refresh actually integrated into the header view: the compute path returns the archive's own presence set alongside the plan, and refresh completion stores that instead of the fact-backed projection. A rebuild that saw a member's whole span satisfies the demand it was spawned for — the invariant that any state demanding a refresh must be satisfiable by that refresh. Durable facts, identity and validation refresh semantics are untouched; every oracle treats extraction readiness as the walkable on-disk chain, and this measures exactly that.